### PR TITLE
Refactor build scripts into modules

### DIFF
--- a/backend/src/scripts/build-frontend.ts
+++ b/backend/src/scripts/build-frontend.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+export const FRONTEND_BUILD_PATH = "src/frontend_build";
+
+export function buildFrontend() {
+    const outputDir = path.join(__dirname, "../../../frontend/out");
+    const targetDir = path.join(__dirname, "../../", FRONTEND_BUILD_PATH);
+
+    try {
+        // Run the build script
+        execSync("npm run build", { cwd: path.join(__dirname, "../../../frontend"), stdio: "inherit" });
+
+        // Check if output directory exists
+        if (fs.existsSync(outputDir)) {
+            // Remove existing contents in the target directory
+            if (fs.existsSync(targetDir)) {
+                fs.rmSync(targetDir, { recursive: true, force: true });
+            }
+
+            // Copy the output directory to the target directory recursively
+            fs.cpSync(outputDir, targetDir, { recursive: true });
+
+            console.log(`Successfully copied build output from ${outputDir} to ${targetDir}`);
+        } else {
+            console.error(`Output directory does not exist: ${outputDir}`);
+            process.exit(1);
+        }
+    } catch (error) {
+        console.error("Error building frontend:", error);
+        process.exit(1);
+    }
+}
+
+// If running directly as a script
+if (require.main === module) {
+    buildFrontend();
+}

--- a/backend/src/scripts/sync-version.ts
+++ b/backend/src/scripts/sync-version.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+
+export function syncVersion() {
+    try {
+        // Read the root package.json
+        const rootPackagePath = path.join(__dirname, '../../../package.json');
+        const rootPackageContent = fs.readFileSync(rootPackagePath, 'utf8');
+        const rootPackage = JSON.parse(rootPackageContent);
+        const version = rootPackage.version;
+
+        if (!version) {
+            console.error('No version found in root package.json');
+            process.exit(1);
+        }
+
+        // Update backend package.json
+        const backendPackagePath = path.join(__dirname, '../../package.json');
+        const backendPackageContent = fs.readFileSync(backendPackagePath, 'utf8');
+        const backendPackage = JSON.parse(backendPackageContent);
+        backendPackage.version = version;
+        fs.writeFileSync(backendPackagePath, JSON.stringify(backendPackage, null, 2) + '\n');
+
+        // Update frontend package.json
+        const frontendPackagePath = path.join(__dirname, '../../../frontend/package.json');
+        const frontendPackageContent = fs.readFileSync(frontendPackagePath, 'utf8');
+        const frontendPackage = JSON.parse(frontendPackageContent);
+        frontendPackage.version = version;
+        fs.writeFileSync(frontendPackagePath, JSON.stringify(frontendPackage, null, 2) + '\n');
+
+        console.log(`Successfully synced version ${version} across all package.json files`);
+    } catch (error) {
+        console.error('Error syncing versions:', error);
+        process.exit(1);
+    }
+}
+
+// If running directly as a script
+if (require.main === module) {
+    syncVersion();
+}


### PR DESCRIPTION
This PR improves the build process by:

- Moving frontend build logic into a dedicated module
- Moving version sync logic into a dedicated module
- Removing duplicate code
- Improving error handling
- Making scripts reusable and runnable independently

Both `sync-version.ts` and `build-frontend.ts` can be run as standalone scripts or imported as modules.